### PR TITLE
feat: show confirmation before exit if logged in

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1,5 +1,5 @@
 const { URL } = require('url');
-const { app, BrowserWindow, Menu, powerSaveBlocker } = require('electron');
+const { app, BrowserWindow, dialog, Menu, powerSaveBlocker } = require('electron');
 const { updateElectronApp } = require('update-electron-app');
 const windowStateKeeper = require('electron-window-state');
 
@@ -47,6 +47,22 @@ function createWindow() {
             if (win.webContents.zoomFactor > 0.6) {
                 win.webContents.zoomFactor -= 0.1;
             }
+        }
+    });
+
+    win.webContents.on('will-prevent-unload', (event) => {
+        // Game engine attempts to prevent unload if user is logged in while
+        // navigating away. We forward event here to our UI shell.
+        const choice = dialog.showMessageBoxSync(win, {
+            type: 'question',
+            buttons: ['Exit', 'Stay'],
+            title: 'Do you want to exit the game?',
+            message: 'You appear to still be logged in.',
+            defaultId: 0,
+            cancelId: 1
+        });
+        if (choice === 0) {
+            event.preventDefault();
         }
     });
 


### PR DESCRIPTION
This will only show if you're logged in. It prevents accidental Ctrl+W/F5/navigation mouse buttons/etc.

Relies on game engine support for calling `preventDefault` on `unbeforeunload` if logged in. (https://github.com/LostCityRS/Client-TS/pull/19)

![browser_exit_warning](https://github.com/user-attachments/assets/41c64a96-7549-411d-ac1b-6e404a6765f6)
